### PR TITLE
Update CodeMirror CSS URL

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -8,7 +8,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico?v2">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-  <link href="https://codemirror.net/5/lib/codemirror.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/codemirror@5/lib/codemirror.css" rel="stylesheet">
   <script>
     window.pendingMap = new Promise((resolve) => {
       window.initMap = () => resolve();


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/bigquery-geo-viz/issues/74.

It seems that codemirror.net doesn't allow third-party to reference its CSS anymore, breaking the query input box. Load the CSS from JSdelivr instead (arbitrary choice, any CDN should do).

A better fix might be to bundle the CSS at build-time but I'm not familiar enough with Angular to do that.