### PR TITLE
Add indexing functionality to view results one by one

### DIFF
--- a/src/app/main/main.component.css
+++ b/src/app/main/main.component.css
@@ -132,3 +132,32 @@ mat-progress-spinner {
 .mat-raised-button[disabled] {
     background: #e5e3df;
 }
+
+.query-buttons {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 8px;
+    flex-wrap: wrap;
+}
+
+.pagination-container {
+    display: flex;
+    align-items: center;
+    justify-items: center;
+    gap: 8px;
+}
+.pagination-span {
+    width: 72px;
+    text-align: center;
+}
+.pagination-input::-webkit-outer-spin-button,
+.pagination-input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+}
+.pagination-input[type=number] {
+  -moz-appearance: textfield;
+  width: 72px;
+  box-sizing: border-box;
+  text-align: center;
+}

--- a/src/app/main/main.component.html
+++ b/src/app/main/main.component.html
@@ -14,7 +14,7 @@
 <div class="view">
   <mat-sidenav-container class="sidenav-container">
     <mat-sidenav-content>
-      <app-map [rows]="rows" [geoColumn]="schemaFormGroup.controls.geoColumn.value" [styles]="styles"></app-map>
+      <app-map [rows]="rows" [page]="page" [geoColumn]="schemaFormGroup.controls.geoColumn.value" [styles]="styles"></app-map>
     </mat-sidenav-content>
     <mat-sidenav #sidenav mode="side" position="start" [(opened)]="sideNavOpened">
       <section class="drawer">
@@ -37,39 +37,62 @@
               <codemirror ref="codemirror" formControlName="sql" ([ngModel])="model" [config]="cmConfig"
                 (change)="dryRun()" (query)="query()"></codemirror>
 
-              <div>
+              <div class="query-buttons">
                 <button mat-raised-button color="primary" (click)="query(stepper)"
                   [disabled]="!dataFormGroup.valid || pending">Run</button>
+                  <p>{{ displayIndex }}</p>
+                
                 <button mat-raised-button color="primary" matStepperNext [disabled]="!rows.length || pending"
                   [matTooltip]="rows.length !== totalRows ? 'Results may be truncated due to size and performance limitations. Selecting fewer columns or less data may increase this limit.'
                                                                 : null" matTooltipPosition="after">
                   Show results ({{ rows.length | number }}<span *ngIf="rows.length !== totalRows"> of
                     {{ totalRows | number }}</span>)
                 </button>
+                <div class="pagination-container">
+
+                  <button mat-icon-button color="primary" (click)="paginate(-1)" [disabled]="!rows.length || pending || rows.length <= 1 || page === 0">&lt;</button>
+                  <span class="pagination-span" *ngIf="!isEditingPagination" (click)="rows.length && rows.length > 0 && !pending && startPaginationEditing()">
+                    {{ page === 0 ? 'All results' : (page) }}
+                  </span>
+                  <input
+                    #pageInput
+                    class="pagination-input"
+                    [attr.autofocus]="true"
+                    *ngIf="isEditingPagination"
+                    [value]="page === 0 ? '' : page"
+                    min="0"
+                    max="rows.length"
+                    (blur)="finishPaginationEditing($event)"
+                    (keydown.enter)="finishPaginationEditing($event)"
+                    type="number"
+                  />
+                  <button mat-icon-button color="primary" (click)="paginate(1)" [disabled]="!rows.length || pending || rows.length <= 1 || page === rows.length">&gt;</button>
+                </div>
                 <mat-progress-spinner *ngIf="pending" mode="indeterminate" [diameter]="24" [strokeWidth]="4">
                 </mat-progress-spinner>
-                <p class="sql-caption" *ngIf="bytesProcessed >= 0">
-                  Estimated query size: {{ bytesProcessed | fileSize:1 }}
-                </p>
-                <p *ngIf="lintMessage" class="sql-lint">{{ lintMessage }}</p>
-                <mat-form-field class="wide sql-location">
-                  <mat-select placeholder="Processing location" formControlName="location" ([ngModel])="model"
-                    matTooltip="Select processing location." matTooltipPosition="after">
-                    <mat-option value="">Auto-select</mat-option>
-                    <mat-option value="US">United States (US)</mat-option>
-                    <mat-option value="EU">European Union (EU)</mat-option>
-                    <mat-option value="us-east4">Northern Virginia (us-east4)</mat-option>
-                    <mat-option value="northamerica-northeast1">Montréal (northamerica-northeast1)</mat-option>
-                    <mat-option value="europe-west2">London (europe-west2)</mat-option>
-                    <mat-option value="europe-north1">Finland (europe-north1)</mat-option>
-                    <mat-option value="asia-south1">Mumbai (asia-south1)</mat-option>
-                    <mat-option value="asia-southeast1">Singapore (asia-southeast1)</mat-option>
-                    <mat-option value="asia-east1">Taiwan (asia-east1)</mat-option>
-                    <mat-option value="asia-northeast1">Tokyo (asia-northeast1)</mat-option>
-                    <mat-option value="australia-southeast1">Sydney (australia-southeast1)</mat-option>
-                  </mat-select>
-                </mat-form-field>
               </div>
+              
+              <p class="sql-caption" *ngIf="bytesProcessed >= 0">
+                Estimated query size: {{ bytesProcessed | fileSize:1 }}
+              </p>
+              <p *ngIf="lintMessage" class="sql-lint">{{ lintMessage }}</p>
+              <mat-form-field class="wide sql-location">
+                <mat-select placeholder="Processing location" formControlName="location" ([ngModel])="model"
+                  matTooltip="Select processing location." matTooltipPosition="after">
+                  <mat-option value="">Auto-select</mat-option>
+                  <mat-option value="US">United States (US)</mat-option>
+                  <mat-option value="EU">European Union (EU)</mat-option>
+                  <mat-option value="us-east4">Northern Virginia (us-east4)</mat-option>
+                  <mat-option value="northamerica-northeast1">Montréal (northamerica-northeast1)</mat-option>
+                  <mat-option value="europe-west2">London (europe-west2)</mat-option>
+                  <mat-option value="europe-north1">Finland (europe-north1)</mat-option>
+                  <mat-option value="asia-south1">Mumbai (asia-south1)</mat-option>
+                  <mat-option value="asia-southeast1">Singapore (asia-southeast1)</mat-option>
+                  <mat-option value="asia-east1">Taiwan (asia-east1)</mat-option>
+                  <mat-option value="asia-northeast1">Tokyo (asia-northeast1)</mat-option>
+                  <mat-option value="australia-southeast1">Sydney (australia-southeast1)</mat-option>
+                </mat-select>
+              </mat-form-field>
             </form>
           </mat-step>
 

--- a/src/app/main/main.component.ts
+++ b/src/app/main/main.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, ChangeDetectorRef, Inject, NgZone, OnInit, OnDestroy } from '@angular/core';
+import { Component, ChangeDetectorRef, Inject, NgZone, OnInit, OnDestroy, ViewChild, ElementRef } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { FormBuilder, FormGroup, FormControl, FormArray, Validators } from '@angular/forms';
 import { LOCAL_STORAGE, WebStorageService } from 'angular-webstorage-service';
@@ -113,6 +113,11 @@ export class MainComponent implements OnInit, OnDestroy {
   // UI state
   stepIndex: Number = 0;
 
+  // Index for viewing geojson data one-by-one, 0 indicates view all data.
+  page: number = 0;
+  isEditingPagination: boolean = false 
+  @ViewChild('pageInput') pageInput: ElementRef;
+
   // Current style rules
   styles: Array<StyleRule> = [];
 
@@ -150,6 +155,7 @@ export class MainComponent implements OnInit, OnDestroy {
     this.columnNames = [];
     this.geoColumnNames = [];
     this.rows = [];
+    this.page = 0;
 
     // Read parameters from URL
     this.projectID = this._route.snapshot.paramMap.get("project");
@@ -464,6 +470,9 @@ ${USER_QUERY_END_MARKER}\n
     // Clear the existing sharing URL.
     this.clearGeneratedSharingUrl();
 
+    // Reset the data index
+    this.page = 0
+
     let geoColumns;
 
     this._dryRun()
@@ -504,6 +513,43 @@ ${USER_QUERY_END_MARKER}\n
       });
 
   }
+
+  paginate(_page: number) {
+    // Left button was pressed
+    console.log(this.page, this.totalRows)
+    if (_page === -1 && this.page !== 0) { 
+      this.page -= 1;
+    } // Right button was pressed
+    else if (_page === 1 && this.page != this.totalRows) {
+      this.page += 1;
+    }
+  }
+
+  startPaginationEditing() {
+    this.isEditingPagination = true;
+    setTimeout(() => {
+      this.pageInput.nativeElement.focus();
+    });
+  }
+
+  finishPaginationEditing(event: Event) {
+    const input = event.target as HTMLInputElement;
+    const value = input.value;
+    
+
+    if (!value) {
+      this.page = 0;
+    }
+    const newPage = parseInt(value, 10);
+    if (!isNaN(newPage) && newPage >= 0 && newPage <= this.rows.length) {
+      this.page = newPage;
+    }
+    this.isEditingPagination = false;
+  }
+
+
+
+
 
   onApplyStylesClicked() {
     this.clearGeneratedSharingUrl();

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -53,6 +53,7 @@ export class MapComponent implements AfterViewInit {
   private _styles: StyleRule[] = [];
   private _geoColumn: string;
   private _activeGeometryTypes = new Set<string>();
+  private _geoJSONLayer = new GeoJsonLayer();
 
   // Detects how many times we have received new values.      
   private _numChanges = 0;
@@ -61,6 +62,9 @@ export class MapComponent implements AfterViewInit {
 
   private _deckLayer: GoogleMapsOverlay = null;
   private _iterableDiffer = null;
+  
+  // Index for viewing geojson data one-by-one, 0 indicates view all data.
+  private _page: number = 0;
 
   @Input()
   set rows(rows: object[]) {
@@ -74,6 +78,12 @@ export class MapComponent implements AfterViewInit {
   set geoColumn(geoColumn: string) {
     this._geoColumn = geoColumn;
     this.updateFeatures();
+    this.updateStyles();
+  }
+
+  @Input()
+  set page(page: number) {
+    this._page = page;
     this.updateStyles();
   }
 
@@ -129,6 +139,7 @@ export class MapComponent implements AfterViewInit {
           this.map.addListener('click', (e) => this._onClick(e));
         });
       });
+    console.log("page init again for some reason")
   }
 
   _onClick(e: google.maps.MouseEvent) {
@@ -171,6 +182,12 @@ export class MapComponent implements AfterViewInit {
     if (!bounds.isEmpty()) { this.map.fitBounds(bounds); }
   }
 
+
+  updatePage() {
+    if (!this.map) return;
+    // const data = this._page === -1 ? this._features : [this._features[this._page]];
+    const layer = this._deckLayer.props.layers.find(l => l.id === LAYER_ID);
+  }
   /**
    * Updates styles applied to all GeoJSON features.
    */
@@ -185,7 +202,7 @@ export class MapComponent implements AfterViewInit {
     const colorRe = /(\d+), (\d+), (\d+)/;
     const layer = new GeoJsonLayer({
       id: LAYER_ID,
-      data: this._features,
+      data: this._page === 0 ? this._features : [this._features[this._page - 1]],
       pickable: true,
       autoHighlight: true,
       highlightColor: [219, 68, 55], // #DB4437
@@ -193,6 +210,7 @@ export class MapComponent implements AfterViewInit {
       filled: true,
       extruded: false,
       elevationScale: 0,
+      binary: true,
       lineWidthUnits: 'pixels',
       pointRadiusMinPixels: 1,
       getFillColor: (d) => {


### PR DESCRIPTION
#### Description:
- Added a number input field to view certain results one-by-one.


#### Testing:
- Tested the input field on multiple different states including ```pending```, when a new query is ran, when the input field is focused, etc. and seemed to work appropriately.
- ```npm run test``` did not find any new errors.

#### Relevant Issue:
https://boi-ucsb.atlassian.net/browse/ENG-230?atlOrigin=eyJpIjoiODc2MTE1ZDkwMjM0NDYzZTllNmZiNmZjYTMwZWQ0Y2QiLCJwIjoiaiJ9
 

<img width="545" alt="Screenshot 2024-10-14 at 1 11 24 PM" src="https://github.com/user-attachments/assets/a91fb25f-e33c-4d3b-a706-53132f2cadfa">
