### PR TITLE
Add indexing functionality to view row results one by one

### DIFF
--- a/src/app/main/main.component.css
+++ b/src/app/main/main.component.css
@@ -132,3 +132,33 @@ mat-progress-spinner {
 .mat-raised-button[disabled] {
     background: #e5e3df;
 }
+
+.query-buttons {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 8px;
+    flex-wrap: wrap;
+}
+
+.pagination-container {
+    display: flex;
+    align-items: center;
+    justify-items: center;
+    gap: 8px;
+    
+}
+.pagination-span {
+    width: 72px;
+    text-align: center;
+}
+.pagination-input::-webkit-outer-spin-button,
+.pagination-input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+}
+.pagination-input[type=number] {
+  -moz-appearance: textfield;
+  width: 72px;
+  box-sizing: border-box;
+  text-align: center;
+}

--- a/src/app/main/main.component.css
+++ b/src/app/main/main.component.css
@@ -133,14 +133,6 @@ mat-progress-spinner {
     background: #e5e3df;
 }
 
-.query-buttons {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin-top: 8px;
-    flex-wrap: wrap;
-}
-
 .pagination-container {
     display: flex;
     align-items: center;
@@ -161,4 +153,9 @@ mat-progress-spinner {
   width: 72px;
   box-sizing: border-box;
   text-align: center;
+}
+.flex {
+    display: flex;
+    align-items: center;
+    gap: 16px;
 }

--- a/src/app/main/main.component.html
+++ b/src/app/main/main.component.html
@@ -14,7 +14,7 @@
 <div class="view">
   <mat-sidenav-container class="sidenav-container">
     <mat-sidenav-content>
-      <app-map [rows]="rows" [page]="page" [geoColumn]="schemaFormGroup.controls.geoColumn.value" [styles]="styles"></app-map>
+      <app-map (maxPaginationChange)="handleMaxPaginationChange($event)" [rows]="rows" [page]="page" [geoColumn]="schemaFormGroup.controls.geoColumn.value" [styles]="styles"></app-map>
     </mat-sidenav-content>
     <mat-sidenav #sidenav mode="side" position="start" [(opened)]="sideNavOpened">
       <section class="drawer">
@@ -33,25 +33,59 @@
                   </mat-option>
                 </mat-autocomplete>
               </mat-form-field>
-
               <codemirror ref="codemirror" formControlName="sql" ([ngModel])="model" [config]="cmConfig"
                 (change)="dryRun()" (query)="query()"></codemirror>
-
-              <div class="query-buttons">
+              <div>
                 <button mat-raised-button color="primary" (click)="query(stepper)"
                   [disabled]="!dataFormGroup.valid || pending">Run</button>
-                  <p>{{ displayIndex }}</p>
-                
                 <button mat-raised-button color="primary" matStepperNext [disabled]="!rows.length || pending"
                   [matTooltip]="rows.length !== totalRows ? 'Results may be truncated due to size and performance limitations. Selecting fewer columns or less data may increase this limit.'
                                                                 : null" matTooltipPosition="after">
                   Show results ({{ rows.length | number }}<span *ngIf="rows.length !== totalRows"> of
                     {{ totalRows | number }}</span>)
                 </button>
-                <div class="pagination-container">
+                <mat-progress-spinner *ngIf="pending" mode="indeterminate" [diameter]="24" [strokeWidth]="4">
+                </mat-progress-spinner>
+                <p class="sql-caption" *ngIf="bytesProcessed >= 0">
+                  Estimated query size: {{ bytesProcessed | fileSize:1 }}
+                </p>
+                <p *ngIf="lintMessage" class="sql-lint">{{ lintMessage }}</p>
+                <mat-form-field class="wide sql-location">
+                  <mat-select placeholder="Processing location" formControlName="location" ([ngModel])="model"
+                    matTooltip="Select processing location." matTooltipPosition="after">
+                    <mat-option value="">Auto-select</mat-option>
+                    <mat-option value="US">United States (US)</mat-option>
+                    <mat-option value="EU">European Union (EU)</mat-option>
+                    <mat-option value="us-east4">Northern Virginia (us-east4)</mat-option>
+                    <mat-option value="northamerica-northeast1">Montréal (northamerica-northeast1)</mat-option>
+                    <mat-option value="europe-west2">London (europe-west2)</mat-option>
+                    <mat-option value="europe-north1">Finland (europe-north1)</mat-option>
+                    <mat-option value="asia-south1">Mumbai (asia-south1)</mat-option>
+                    <mat-option value="asia-southeast1">Singapore (asia-southeast1)</mat-option>
+                    <mat-option value="asia-east1">Taiwan (asia-east1)</mat-option>
+                    <mat-option value="asia-northeast1">Tokyo (asia-northeast1)</mat-option>
+                    <mat-option value="australia-southeast1">Sydney (australia-southeast1)</mat-option>
+                  </mat-select>
+                </mat-form-field>
+              </div>
+            </form>
+          </mat-step>
 
-                  <button mat-icon-button color="primary" (click)="paginate(-1)" [disabled]="!rows.length || pending || rows.length <= 1 || page === 0">&lt;</button>
-                  <span class="pagination-span" [ngStyle]="{ 'cursor': (rows.length && rows.length > 0) ? 'pointer' : 'default' }" *ngIf="!isEditingPagination" (click)="rows.length && rows.length > 0 && !pending && startPaginationEditing()">
+          <mat-step [stepControl]="schemaFormGroup" label="Data">
+            <div style="margin-bottom: 2em">
+              <button mat-raised-button color="primary" matStepperNext>Add styles</button>
+            </div>
+            <form [formGroup]="schemaFormGroup">
+              <div class="flex">
+                <mat-form-field class="wide">
+                  <mat-select placeholder="Geometry column" formControlName="geoColumn" ([ngModel])="model"
+                    matTooltip="Select field containing WKT-formatted geometry" matTooltipPosition="after">
+                    <mat-option *ngFor="let column of geoColumnNames" [value]="column">{{ column }}</mat-option>
+                  </mat-select>
+                </mat-form-field>
+                <div class="pagination-container" *ngIf="!pending && rows.length">
+                  <button mat-icon-button color="primary" (click)="paginate(-1)" [disabled]="!rows.length || pending || maxPagination === 0 || page === 0">&lt;</button>
+                  <span class="pagination-span" [ngStyle]="{ 'cursor': (rows.length && maxPagination > 1) ? 'pointer' : 'default' }" *ngIf="!isEditingPagination" (click)="rows.length && maxPagination > 1 && !pending && startPaginationEditing()">
                     {{ page === 0 ? 'All results' : (page) }}
                   </span>
                   <input
@@ -61,52 +95,14 @@
                     *ngIf="isEditingPagination"
                     [value]="page === 0 ? '' : page"
                     min="0"
-                    max="rows.length"
+                    max="maxPagination"
                     (blur)="finishPaginationEditing($event)"
                     (keydown.enter)="finishPaginationEditing($event)"
                     type="number"
                   />
-                  <button mat-icon-button color="primary" (click)="paginate(1)" [disabled]="!rows.length || pending || rows.length <= 1 || page === rows.length">&gt;</button>
+                  <button mat-icon-button color="primary" (click)="paginate(1)" [disabled]="!rows.length || pending || maxPagination <= 1 || page === maxPagination">&gt;</button>
                 </div>
-                <mat-progress-spinner *ngIf="pending" mode="indeterminate" [diameter]="24" [strokeWidth]="4">
-                </mat-progress-spinner>
               </div>
-              
-              <p class="sql-caption" *ngIf="bytesProcessed >= 0">
-                Estimated query size: {{ bytesProcessed | fileSize:1 }}
-              </p>
-              <p *ngIf="lintMessage" class="sql-lint">{{ lintMessage }}</p>
-              <mat-form-field class="wide sql-location">
-                <mat-select placeholder="Processing location" formControlName="location" ([ngModel])="model"
-                  matTooltip="Select processing location." matTooltipPosition="after">
-                  <mat-option value="">Auto-select</mat-option>
-                  <mat-option value="US">United States (US)</mat-option>
-                  <mat-option value="EU">European Union (EU)</mat-option>
-                  <mat-option value="us-east4">Northern Virginia (us-east4)</mat-option>
-                  <mat-option value="northamerica-northeast1">Montréal (northamerica-northeast1)</mat-option>
-                  <mat-option value="europe-west2">London (europe-west2)</mat-option>
-                  <mat-option value="europe-north1">Finland (europe-north1)</mat-option>
-                  <mat-option value="asia-south1">Mumbai (asia-south1)</mat-option>
-                  <mat-option value="asia-southeast1">Singapore (asia-southeast1)</mat-option>
-                  <mat-option value="asia-east1">Taiwan (asia-east1)</mat-option>
-                  <mat-option value="asia-northeast1">Tokyo (asia-northeast1)</mat-option>
-                  <mat-option value="australia-southeast1">Sydney (australia-southeast1)</mat-option>
-                </mat-select>
-              </mat-form-field>
-            </form>
-          </mat-step>
-
-          <mat-step [stepControl]="schemaFormGroup" label="Data">
-            <div style="margin-bottom: 2em">
-              <button mat-raised-button color="primary" matStepperNext>Add styles</button>
-            </div>
-            <form [formGroup]="schemaFormGroup">
-              <mat-form-field class="wide">
-                <mat-select placeholder="Geometry column" formControlName="geoColumn" ([ngModel])="model"
-                  matTooltip="Select field containing WKT-formatted geometry" matTooltipPosition="after">
-                  <mat-option *ngFor="let column of geoColumnNames" [value]="column">{{ column }}</mat-option>
-                </mat-select>
-              </mat-form-field>
               <mat-table *ngIf="data" [dataSource]="data" class="result-table">
                 <ng-container *ngFor="let column of columnNames; let i = index" [matColumnDef]="column">
                   <mat-header-cell *matHeaderCellDef>
@@ -120,6 +116,9 @@
                 <mat-row *matRowDef="let row; columns: columnNames;" [ngStyle]="{'min-width': getRowWidth()}"></mat-row>
               </mat-table>
             </form>
+            <p class="sql-caption" *ngIf="!pending && rows.length">
+              Total rows displayed: {{ maxPagination }}
+            </p>
           </mat-step>
 
           <mat-step [stepControl]="stylesFormGroup" label="Style">

--- a/src/app/main/main.component.html
+++ b/src/app/main/main.component.html
@@ -14,7 +14,7 @@
 <div class="view">
   <mat-sidenav-container class="sidenav-container">
     <mat-sidenav-content>
-      <app-map [rows]="rows" [geoColumn]="schemaFormGroup.controls.geoColumn.value" [styles]="styles"></app-map>
+      <app-map [rows]="rows" [page]="page" [geoColumn]="schemaFormGroup.controls.geoColumn.value" [styles]="styles"></app-map>
     </mat-sidenav-content>
     <mat-sidenav #sidenav mode="side" position="start" [(opened)]="sideNavOpened">
       <section class="drawer">
@@ -37,39 +37,62 @@
               <codemirror ref="codemirror" formControlName="sql" ([ngModel])="model" [config]="cmConfig"
                 (change)="dryRun()" (query)="query()"></codemirror>
 
-              <div>
+              <div class="query-buttons">
                 <button mat-raised-button color="primary" (click)="query(stepper)"
                   [disabled]="!dataFormGroup.valid || pending">Run</button>
+                  <p>{{ displayIndex }}</p>
+                
                 <button mat-raised-button color="primary" matStepperNext [disabled]="!rows.length || pending"
                   [matTooltip]="rows.length !== totalRows ? 'Results may be truncated due to size and performance limitations. Selecting fewer columns or less data may increase this limit.'
                                                                 : null" matTooltipPosition="after">
                   Show results ({{ rows.length | number }}<span *ngIf="rows.length !== totalRows"> of
                     {{ totalRows | number }}</span>)
                 </button>
+                <div class="pagination-container">
+
+                  <button mat-icon-button color="primary" (click)="paginate(-1)" [disabled]="!rows.length || pending || rows.length <= 1 || page === 0">&lt;</button>
+                  <span class="pagination-span" [ngStyle]="{ 'cursor': (rows.length && rows.length > 0) ? 'pointer' : 'default' }" *ngIf="!isEditingPagination" (click)="rows.length && rows.length > 0 && !pending && startPaginationEditing()">
+                    {{ page === 0 ? 'All results' : (page) }}
+                  </span>
+                  <input
+                    #pageInput
+                    class="pagination-input"
+                    [attr.autofocus]="true"
+                    *ngIf="isEditingPagination"
+                    [value]="page === 0 ? '' : page"
+                    min="0"
+                    max="rows.length"
+                    (blur)="finishPaginationEditing($event)"
+                    (keydown.enter)="finishPaginationEditing($event)"
+                    type="number"
+                  />
+                  <button mat-icon-button color="primary" (click)="paginate(1)" [disabled]="!rows.length || pending || rows.length <= 1 || page === rows.length">&gt;</button>
+                </div>
                 <mat-progress-spinner *ngIf="pending" mode="indeterminate" [diameter]="24" [strokeWidth]="4">
                 </mat-progress-spinner>
-                <p class="sql-caption" *ngIf="bytesProcessed >= 0">
-                  Estimated query size: {{ bytesProcessed | fileSize:1 }}
-                </p>
-                <p *ngIf="lintMessage" class="sql-lint">{{ lintMessage }}</p>
-                <mat-form-field class="wide sql-location">
-                  <mat-select placeholder="Processing location" formControlName="location" ([ngModel])="model"
-                    matTooltip="Select processing location." matTooltipPosition="after">
-                    <mat-option value="">Auto-select</mat-option>
-                    <mat-option value="US">United States (US)</mat-option>
-                    <mat-option value="EU">European Union (EU)</mat-option>
-                    <mat-option value="us-east4">Northern Virginia (us-east4)</mat-option>
-                    <mat-option value="northamerica-northeast1">Montréal (northamerica-northeast1)</mat-option>
-                    <mat-option value="europe-west2">London (europe-west2)</mat-option>
-                    <mat-option value="europe-north1">Finland (europe-north1)</mat-option>
-                    <mat-option value="asia-south1">Mumbai (asia-south1)</mat-option>
-                    <mat-option value="asia-southeast1">Singapore (asia-southeast1)</mat-option>
-                    <mat-option value="asia-east1">Taiwan (asia-east1)</mat-option>
-                    <mat-option value="asia-northeast1">Tokyo (asia-northeast1)</mat-option>
-                    <mat-option value="australia-southeast1">Sydney (australia-southeast1)</mat-option>
-                  </mat-select>
-                </mat-form-field>
               </div>
+              
+              <p class="sql-caption" *ngIf="bytesProcessed >= 0">
+                Estimated query size: {{ bytesProcessed | fileSize:1 }}
+              </p>
+              <p *ngIf="lintMessage" class="sql-lint">{{ lintMessage }}</p>
+              <mat-form-field class="wide sql-location">
+                <mat-select placeholder="Processing location" formControlName="location" ([ngModel])="model"
+                  matTooltip="Select processing location." matTooltipPosition="after">
+                  <mat-option value="">Auto-select</mat-option>
+                  <mat-option value="US">United States (US)</mat-option>
+                  <mat-option value="EU">European Union (EU)</mat-option>
+                  <mat-option value="us-east4">Northern Virginia (us-east4)</mat-option>
+                  <mat-option value="northamerica-northeast1">Montréal (northamerica-northeast1)</mat-option>
+                  <mat-option value="europe-west2">London (europe-west2)</mat-option>
+                  <mat-option value="europe-north1">Finland (europe-north1)</mat-option>
+                  <mat-option value="asia-south1">Mumbai (asia-south1)</mat-option>
+                  <mat-option value="asia-southeast1">Singapore (asia-southeast1)</mat-option>
+                  <mat-option value="asia-east1">Taiwan (asia-east1)</mat-option>
+                  <mat-option value="asia-northeast1">Tokyo (asia-northeast1)</mat-option>
+                  <mat-option value="australia-southeast1">Sydney (australia-southeast1)</mat-option>
+                </mat-select>
+              </mat-form-field>
             </form>
           </mat-step>
 

--- a/src/app/main/main.component.ts
+++ b/src/app/main/main.component.ts
@@ -115,6 +115,8 @@ export class MainComponent implements OnInit, OnDestroy {
 
   // Index for viewing geojson data one-by-one, 0 indicates view all data.
   page: number = 0;
+  // Maximum number of features actually displayed on map (differs from total rows if some rows contain null value for a geometry column)
+  maxPagination: number = 0; 
   isEditingPagination: boolean = false 
   @ViewChild('pageInput') pageInput: ElementRef;
 
@@ -182,6 +184,9 @@ export class MainComponent implements OnInit, OnDestroy {
 
     // Schema form group
     this.schemaFormGroup = this._formBuilder.group({ geoColumn: [''] });
+    this.schemaFormGroup.get('geoColumn').valueChanges.subscribe(newValue => {
+      this.page = 0;
+    });
 
     // Style rules form group
     const stylesGroupMap = {};
@@ -514,13 +519,16 @@ ${USER_QUERY_END_MARKER}\n
 
   }
 
+  handleMaxPaginationChange(maxPagination: number) {
+    this.maxPagination = maxPagination;
+  }
+
   paginate(_page: number) {
     // Left button was pressed
-    console.log(this.page, this.totalRows)
     if (_page === -1 && this.page !== 0) { 
       this.page -= 1;
     } // Right button was pressed
-    else if (_page === 1 && this.page != this.totalRows) {
+    else if (_page === 1 && this.page != this.maxPagination) {
       this.page += 1;
     }
   }
@@ -536,7 +544,6 @@ ${USER_QUERY_END_MARKER}\n
     const input = event.target as HTMLInputElement;
     const value = input.value;
     
-
     if (!value) {
       this.page = 0;
     }
@@ -545,8 +552,8 @@ ${USER_QUERY_END_MARKER}\n
     if (!isNaN(newPage)) {
       if (newPage < 0) {
         this.page = 0;
-      } else if (newPage > this.rows.length) {
-        this.page = this.rows.length;
+      } else if (newPage > this.maxPagination) {
+        this.page = this.maxPagination;
       }
       else {
         this.page = newPage;
@@ -554,10 +561,6 @@ ${USER_QUERY_END_MARKER}\n
     }
     this.isEditingPagination = false;
   }
-
-
-
-
 
   onApplyStylesClicked() {
     this.clearGeneratedSharingUrl();

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -53,6 +53,7 @@ export class MapComponent implements AfterViewInit {
   private _styles: StyleRule[] = [];
   private _geoColumn: string;
   private _activeGeometryTypes = new Set<string>();
+  private _geoJSONLayer = new GeoJsonLayer();
 
   // Detects how many times we have received new values.      
   private _numChanges = 0;
@@ -61,6 +62,9 @@ export class MapComponent implements AfterViewInit {
 
   private _deckLayer: GoogleMapsOverlay = null;
   private _iterableDiffer = null;
+  
+  // Index for viewing geojson data one-by-one, 0 indicates view all data.
+  private _page: number = 0;
 
   @Input()
   set rows(rows: object[]) {
@@ -74,6 +78,12 @@ export class MapComponent implements AfterViewInit {
   set geoColumn(geoColumn: string) {
     this._geoColumn = geoColumn;
     this.updateFeatures();
+    this.updateStyles();
+  }
+
+  @Input()
+  set page(page: number) {
+    this._page = page;
     this.updateStyles();
   }
 
@@ -129,6 +139,7 @@ export class MapComponent implements AfterViewInit {
           this.map.addListener('click', (e) => this._onClick(e));
         });
       });
+    console.log("page init again for some reason")
   }
 
   _onClick(e: google.maps.MouseEvent) {
@@ -171,6 +182,12 @@ export class MapComponent implements AfterViewInit {
     if (!bounds.isEmpty()) { this.map.fitBounds(bounds); }
   }
 
+
+  updatePage() {
+    if (!this.map) return;
+    // const data = this._page === -1 ? this._features : [this._features[this._page]];
+    const layer = this._deckLayer.props.layers.find(l => l.id === LAYER_ID);
+  }
   /**
    * Updates styles applied to all GeoJSON features.
    */
@@ -185,7 +202,7 @@ export class MapComponent implements AfterViewInit {
     const colorRe = /(\d+), (\d+), (\d+)/;
     const layer = new GeoJsonLayer({
       id: LAYER_ID,
-      data: this._features,
+      data: this._page === 0 ? this._features : [this._features[this._page - 1]],
       pickable: true,
       autoHighlight: true,
       highlightColor: [219, 68, 55], // #DB4437
@@ -193,6 +210,7 @@ export class MapComponent implements AfterViewInit {
       filled: true,
       extruded: false,
       elevationScale: 0,
+      binary: true,
       lineWidthUnits: 'pixels',
       pointRadiusMinPixels: 1,
       getFillColor: (d) => {

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -186,7 +186,7 @@ export class MapComponent implements AfterViewInit {
   updatePage() {
     if (!this.map) return;
     // const data = this._page === -1 ? this._features : [this._features[this._page]];
-    const layer = this._deckLayer.props.layers.find(l => l.id === LAYER_ID);
+    
   }
   /**
    * Updates styles applied to all GeoJSON features.
@@ -210,7 +210,6 @@ export class MapComponent implements AfterViewInit {
       filled: true,
       extruded: false,
       elevationScale: 0,
-      binary: true,
       lineWidthUnits: 'pixels',
       pointRadiusMinPixels: 1,
       getFillColor: (d) => {


### PR DESCRIPTION
#### Feature Description:
- Allows user to view all results together or select one row to display on the map. 
- Because sometimes a geography column can have null or invalid values, now displaying a caption showing how many rows total there are that is being shown.

#### Testing:
- Tested the input field on multiple different states including pending, when a new query is ran, when the input field is focused, etc. and works appropriately.
- Made sure null values in rows and switching geo columns works appropriately with pagination.
- `npm run test` did not find any new errors.
#### Relevant Issue:
https://github.com/GoogleCloudPlatform/bigquery-geo-viz/issues/73#issue-2461520343

#### Relevant Image:
<img width="608" alt="Screenshot 2024-10-21 at 9 01 58 AM" src="https://github.com/user-attachments/assets/7b55deec-bdc6-47eb-ad0f-b7b1993c2b04">
