### PR TITLE
Set AppEngine runtime to 3.12 and fix deployment scripts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,41 @@ npm run dev
 # Run unit tests with Karma.
 npm test
 ```
+
+### Deploy to your dev project and version
+
+This will run `npm run build`, copy the `app.yaml` into the `dist/` directory
+and deploy the app from there at the specified project and version ID.
+
+```shell
+npm run deploy --project=my-project --app_version=my-version-id
+```
+
+Once deployed, the version will be available to test at the specified project
+and version, e.g.:
+https://my-version-id-dot-my-project.appspot.com
+
+### Deploy to beta (for GeoViz maintainers)
+
+```shell
+npm run deploy:beta
+```
+Once deployed, the version will be available to test here:
+https://beta-dot-bigquerygeoviz.appspot.com
+
+### Deploy to a (prod) version (for GeoViz maintainers)
+
+```shell
+npm run deploy:prod --app_version=my-version-id
+```
+
+Once deployed, the version will be available to test at the specified version:
+https://my-version-id-dot-bigquerygeoviz.appspot.com
+
+To prevent accidentally pushing it live, the version will not be set as default.
+To make it the default version, you will need to
+[migrate it directly on the Cloud Console](https://cloud.google.com/appengine/docs/legacy/standard/python/migrating-traffic).
+
 ### Resources
 
 - [Google Maps JavaScript API documentation](https://developers.google.com/maps/documentation/javascript/)

--- a/app.yaml
+++ b/app.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: python38
+runtime: python312
 
 handlers:
 - url: /

--- a/package.json
+++ b/package.json
@@ -10,11 +10,9 @@
     "test": "ng test",
     "lint": "ng lint",
     "predeploy": "npm run build",
-    "predeploy:beta": "npm run predeploy",
-    "predeploy:dev": "npm run predeploy",
-    "deploy": "cp app.yaml dist/app.yaml && cd dist && gcloud app deploy --project bigquerygeoviz --version prod",
-    "deploy:beta": "cp app.yaml dist/app.yaml && cd dist && gcloud app deploy --project bigquerygeoviz --version beta --no-promote",
-    "deploy:dev": "cp app.yaml dist/app.yaml && cd dist && gcloud app deploy --project google.com:donmccurdy --version bigquerygeoviz --no-promote"
+    "deploy": "cp app.yaml dist/app.yaml && cd dist && gcloud app deploy --project $npm_config_project --version $npm_config_app_version --no-promote",
+    "deploy:beta": "npm run deploy --project=bigquerygeoviz --app_version=beta",
+    "deploy:prod": "npm run deploy --project=bigquerygeoviz --app_version=$npm_config_app_version"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
 - Python 3.12 is set to end of life in 2028: https://cloud.google.com/appengine/docs/standard/lifecycle/support-schedule#python. In the future, we should consider a NodeJS environment to better match the code.

 - Adds new deployment configurations, documented in the README